### PR TITLE
Add maven publishing and library version to gradle

### DIFF
--- a/properties.gradle
+++ b/properties.gradle
@@ -2,6 +2,9 @@
 // Note will not change native library names
 ext.libraryName = "CTRE_Phoenix"
 
+// Library Version
+ext.libraryVersion = "v5.0.6.0"
+
 // Set to true to embed included java libraries in the output jar
 ext.embedJavaLibraries = false
 

--- a/releases.gradle
+++ b/releases.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'maven-publish'
+
 task javaSourceJar(type: Jar) {
     description = 'Generates the source jar for java'
     group = ''
@@ -270,6 +272,17 @@ project(':arm:cpp').tasks.whenTaskAdded { task ->
     }
 }
 
+// Zip release/ for distribution using library version
+task zipRelease(type: Zip) {
+    description = 'Creates a zip of release.'
+    group = ''
+    destinationDir = file("$buildDir/releases")
+    baseName = libraryName
+    version = libraryVersion
+    duplicatesStrategy = 'exclude'
+
+    from(releaseDir)
+}
 
 //build.dependsOn javaSourceJar
 //build.dependsOn javaJavadocJar
@@ -282,4 +295,66 @@ doc.mustRunAfter userStaticArtifacts
 
 if (setCopyToEclipse) {
     build.dependsOn copyToEclipse
+}
+
+// Maven Publishing
+task zipCppHeadersForPublish(type: Zip) {
+    destinationDir = archiveReleaseDir
+    baseName = libraryName
+    classifier = 'cppheaders'
+    duplicatesStrategy = 'exclude'
+    dependsOn userStaticArtifacts
+
+    from("$releaseDir/cpp/include")
+}
+
+task zipCppBinariesForPublish(type: Zip) {
+    destinationDir = archiveReleaseDir
+    baseName = libraryName
+    classifier = 'cppbinaries'
+    duplicatesStrategy = 'exclude'
+    dependsOn userStaticArtifacts
+
+    from("$releaseDir/cpp/lib")
+}
+
+task zipJavaNativeBinariesForPublish(type: Zip) {
+    destinationDir = archiveReleaseDir
+    baseName = libraryName
+    classifier = 'java-binaries'
+    duplicatesStrategy = 'exclude'
+    dependsOn userStaticArtifacts
+
+    from("$releaseDir/java/lib") {
+        include "*.so"
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            url "$buildDir/repo"
+        }
+    }
+    publications {
+        phoenixJava(MavenPublication) {
+            groupId 'com.ctre.phoenix'
+            artifactId 'CTRE-phoenix-java'
+            version libraryVersion
+
+            artifact source: project(':arm:cpp').jar
+            artifact source: javaSourceJar, classifier: 'sources'
+            artifact source: javaJavadocJar, classifier: 'javadoc'
+            artifact source: zipJavaNativeBinariesForPublish, classifier: 'native'
+        }
+
+        phoenixCpp(MavenPublication) {
+            groupId 'com.ctre.phoenix'
+            artifactId 'CTRE-phoenix-cpp'
+            version libraryVersion
+
+            artifact source: zipCppBinariesForPublish, classifier: null
+            artifact source: zipCppHeadersForPublish, classifier: 'headers'
+        }
+    }
 }

--- a/releases.gradle
+++ b/releases.gradle
@@ -280,6 +280,7 @@ task zipRelease(type: Zip) {
     baseName = libraryName
     version = libraryVersion
     duplicatesStrategy = 'exclude'
+    dependsOn build
 
     from(releaseDir)
 }


### PR DESCRIPTION
Per the title.  
Repo location is `build/repo`, although you can change this depending on your prod setup.  
Version is now set in `properties.gradle`, zip a release with `./gradlew build zipRelease` (releases located at build/releases).  
Publish to maven with `./gradlew publish`.  

Maven group is `com.ctre.phoenix` (following java package convention), names are `CTRE-phoenix-java` and `CTRE-phoenix-cpp`. Java has jar, sources, javadoc and native artifacts. Cpp has binary and header artifacts. 