### PR TITLE
Fixed conditional in Logger

### DIFF
--- a/java/src/com/ctre/phoenix/Logger.java
+++ b/java/src/com/ctre/phoenix/Logger.java
@@ -10,7 +10,7 @@ public class Logger
 	 */
 	public static ErrorCode log(ErrorCode code, String origin) {
 		/* only take action if the error code is nonzero */
-		if (code == ErrorCode.OK) {
+		if (code != ErrorCode.OK) {
 			String stack = java.util.Arrays.toString(Thread.currentThread().getStackTrace());
 			stack = stack.replaceAll(",", "\n");
 			int errCode = code.value;


### PR DESCRIPTION
In the file Logger.java, it would appear that the conditional to check if the error code is "OK" is inverted, causing a stack trace to be pulled _only_ when the error code is "OK"