### PR TITLE
Velocity Mode for WPI Wrapper

### DIFF
--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
@@ -45,7 +45,7 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	@Override
 	public void set(double speed) {
 		_speed = speed;
-		if(mode == ControlMode.Velocity) {
+		if(wpiControlMode == ControlMode.Velocity) {
 			set(wpiControlMode, _speed*maxVelocity);
 		} else {
 			set(wpiControlMode, _speed);
@@ -54,7 +54,7 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 		_safetyHelper.feed();
 	}
 	
-	public void setWpiControlMode(ControlMode mode){
+	public void setWPIControlMode(ControlMode mode){
 		if(mode == ControlMode.Velocity) {
 			wpiControlMode = ControlMode.Velocity;
 		} else {

--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
@@ -45,7 +45,7 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	@Override
 	public void set(double speed) {
 		_speed = speed;
-		set(defaultControlMode, _speed);
+		set(defaultControlMode, _speed * scaleFactor);
 		_safetyHelper.feed();
 	}
 	

--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
@@ -24,8 +24,8 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	private String _description;
 	private double _speed;
 	private MotorSafetyHelper _safetyHelper;
-	private ControlMode wpiControlMode = ControlMode.PercentOutput;
-	private double maxVelocity = 1.0;
+	private ControlMode defaultControlMode = ControlMode.PercentOutput;
+	private double scaleFactor = 1.0;
 
 	/** Constructor */
 	public WPI_TalonSRX(int deviceNumber) {
@@ -45,27 +45,20 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	@Override
 	public void set(double speed) {
 		_speed = speed;
-		if(wpiControlMode == ControlMode.Velocity) {
-			set(wpiControlMode, _speed*maxVelocity);
-		} else {
-			set(wpiControlMode, _speed);
-		}
-		
+		set(defaultControlMode, _speed);
 		_safetyHelper.feed();
 	}
 	
-	public void setWPIControlMode(ControlMode mode){
-		if(mode == ControlMode.Velocity) {
-			wpiControlMode = ControlMode.Velocity;
-		} else {
-			wpiControlMode = ControlMode.PercentOutput;
-		}
+	public void setDefaultPercentOutputMode(){
+		defaultControlMode = ControlMode.PercentOutput;
+		scaleFactor = 1.0;
 	}
 	
-	public void setMaxVelocity(double maxVelocity){
-		this.maxVelocity = maxVelocity;
+	public void setDefaultVelocityMode(double maxVelocity){
+		defaultControlMode = ControlMode.Velocity;
+		scaleFactor = maxVelocity;
 	}
-
+	
 	@Override
 	public void pidWrite(double output) {
 		set(output);

--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
@@ -25,6 +25,7 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	private double _speed;
 	private MotorSafetyHelper _safetyHelper;
 	private ControlMode wpiControlMode = ControlMode.PercentOutput;
+	private double maxVelocity = 1.0;
 
 	/** Constructor */
 	public WPI_TalonSRX(int deviceNumber) {
@@ -44,13 +45,25 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	@Override
 	public void set(double speed) {
 		_speed = speed;
-		set(wpiControlMode, _speed);
+		if(mode == ControlMode.Velocity) {
+			set(wpiControlMode, _speed*maxVelocity);
+		} else {
+			set(wpiControlMode, _speed);
+		}
+		
 		_safetyHelper.feed();
 	}
 	
-	
 	public void setWpiControlMode(ControlMode mode){
-		wpiControlMode = mode;
+		if(mode == ControlMode.Velocity) {
+			wpiControlMode = ControlMode.Velocity;
+		} else {
+			wpiControlMode = ControlMode.PercentOutput;
+		}
+	}
+	
+	public void setMaxVelocity(double maxVelocity){
+		this.maxVelocity = maxVelocity;
 	}
 
 	@Override

--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
@@ -24,6 +24,7 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	private String _description;
 	private double _speed;
 	private MotorSafetyHelper _safetyHelper;
+	private ControlMode wpiControlMode = ControlMode.PercentOutput;
 
 	/** Constructor */
 	public WPI_TalonSRX(int deviceNumber) {
@@ -43,8 +44,13 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	@Override
 	public void set(double speed) {
 		_speed = speed;
-		set(ControlMode.PercentOutput, _speed);
+		set(wpiControlMode, _speed);
 		_safetyHelper.feed();
+	}
+	
+	
+	public void setWpiControlMode(ControlMode mode){
+		wpiControlMode = mode;
 	}
 
 	@Override


### PR DESCRIPTION
As requested by a few other teams, I wrote some basic code to allow configuration of the default mode used in the `set()` implementation of the SpeedController to allow velocity as well.

Given that it's such a small change, I thought I'd refactor and share it so additional teams may find it useful.