### PR TITLE
Stops WPI_* wrappers from adding themselves to LiveWindow

### DIFF
--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
@@ -35,7 +35,6 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 		_safetyHelper.setExpiration(0.0);
 		_safetyHelper.setSafetyEnabled(false);
 
-		LiveWindow.add(this);
 		setName("Talon SRX ", deviceNumber);
 	}
 

--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_VictorSPX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_VictorSPX.java
@@ -35,7 +35,6 @@ public class WPI_VictorSPX extends VictorSPX implements SpeedController, Sendabl
 		_safetyHelper.setExpiration(0.0);
 		_safetyHelper.setSafetyEnabled(false);
 
-		LiveWindow.add(this);
 		setName("Victor SPX ", deviceNumber);
 	}
 


### PR DESCRIPTION
A SpeedController isn't supposed to automatically force-add itself to the LiveWindow. This PR corrects it to how other SpeedControllers in WPILib work.