### PR TITLE
TrajectoryPoint's valueOf is static

### DIFF
--- a/java/src/com/ctre/phoenix/motion/TrajectoryPoint.java
+++ b/java/src/com/ctre/phoenix/motion/TrajectoryPoint.java
@@ -27,7 +27,7 @@ public class TrajectoryPoint {
 			this.value = value;
 		}
 
-		public TrajectoryDuration valueOf(int val)
+		public static TrajectoryDuration valueOf(int val)
 		{
 			for(TrajectoryDuration td: TrajectoryDuration.values())
 			{


### PR DESCRIPTION
## Description of change

Trajectory Point's valueOf method is changed to static

## Why this should be added

Making this a static method makes it easier for users to create a TrajectoryPoint enum from an integer, and eliminates the workaround that is currently in place in the examples.

## Test Procedure

Test compilation of Motion Profile Examples

## Test Results

Motion Profile Examples will compile. Example will run as expected.

## Related Pull Requests/Issues

https://github.com/CrossTheRoadElec/Phoenix-frc-lib/issues/21