### PR TITLE
WPI get() fix

### DIFF
--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.java
@@ -59,7 +59,7 @@ public class WPI_TalonSRX extends TalonSRX implements SpeedController, Sendable,
 	 */
 	@Override
 	public double get() {
-		return _speed;
+		return getMotorOutputPercent();
 	}
 
 	// ---------Intercept CTRE calls for motor safety ---------//

--- a/java/src/com/ctre/phoenix/motorcontrol/can/WPI_VictorSPX.java
+++ b/java/src/com/ctre/phoenix/motorcontrol/can/WPI_VictorSPX.java
@@ -59,7 +59,7 @@ public class WPI_VictorSPX extends VictorSPX implements SpeedController, Sendabl
 	 */
 	@Override
 	public double get() {
-		return _speed;
+		return getMotorOutputPercent();
 	}
 
 	// ---------Intercept CTRE calls for motor safety ---------//


### PR DESCRIPTION
When not in percent output mode, calling get() on a WPI_VictorSPX or WPI_TalonSRX will return 0, even if the motor controller is actually outputting to motors (e.g. calling get() on a WPI_VictorSPX that is slave to a Talon SRX will always return 0). If a team uses the Sendable interface to send the WPI_VictorSPX or WPI_TalonSRX to a dashboard, the dashboard will report the information from the get() method. These changes may fix that.